### PR TITLE
Incorporate a new ServiceDescriptorMergeStrategy.Add

### DIFF
--- a/src/Quickwire/ServiceCollectionExtensions.cs
+++ b/src/Quickwire/ServiceCollectionExtensions.cs
@@ -80,6 +80,9 @@ public static class ServiceCollectionExtensions
     {
         switch (mergeStrategy)
         {
+            case ServiceDescriptorMergeStrategy.Add:
+                services.Add(serviceDescriptor);
+                break;
             case ServiceDescriptorMergeStrategy.Replace:
                 services.Replace(serviceDescriptor);
                 break;


### PR DESCRIPTION
The built-in DI container supports registering multiple descriptors for the same type and this is used for several cases. ServiceProvider resolves these by injecting an IEnumerable<> of the registered type.